### PR TITLE
fix: remove leftover iOS RTL justification (investigation of overlapping-letters bug)

### DIFF
--- a/Misc.js
+++ b/Misc.js
@@ -38,7 +38,8 @@ const CSS_CLASS_STYLES = {
     fontFamily: "Taamey Frank Taamim Fix",
     writingDirection: "rtl",
     flex: -1,
-    textAlign: Platform.OS == "android" ? "right" : "justify",
+    // Justification of RTL text is broken on iOS since RN 0.77 (see useHTMLViewStyles.js); use 'right' on both platforms.
+    textAlign: "right",
   },
   english: {
     fontFamily: "Amiri",


### PR DESCRIPTION
_(Claude writing on Daniel's behalf)_

## Context

This PR comes out of investigating the report of Hebrew letters rendering **stacked on top of each other** in the iOS reader (seen on Chullin 11b, segment ט: the words "שֶׁמָּא בִּמְקוֹם נֶקֶב קָא שָׁחֵיט? אֶלָּא" collapse into a zero-width blob at the start of a wrapped line).

## What this PR fixes

`CSS_CLASS_STYLES.hebrew` in `Misc.js` still set `textAlign: 'justify'` on iOS. Commit 937773e9 (May 2025, "fix: only allow justification in Android") established that **justification of RTL text is broken on iOS since RN 0.77** and removed it — but only in `useHTMLViewStyles.js`. In the main reader the leftover is masked (`defaultTextProps` wins the style merge in react-native-render-html), but in `LexiconBox` the class styles are applied last, so dictionary entries still hit the known-broken justify+RTL TextKit path on iOS. This aligns the class style with the documented decision: `right` on both platforms (no behavior change on Android, which was already `right` here).

## Investigation summary (the stacking bug itself)

The stacked-letters artifact could **not** be reproduced in the simulator despite an extensive matrix:

- iPhone 16 / 16 Plus, iOS 18.6 and 26.5, English and Hebrew (RTL) device locales
- Integer and fractional font sizes (the `incrementFont` ×1.1/×0.9 path produces sizes like 26.62/29.28 — tested)
- Dynamic stress: automated font-size cycling and continuous scroll (Fabric view recycling) with automated screenshot analysis (~150 captures, dark-cluster blob detector)
- Verified the offline bundle (`ios-export/7`) text for Chullin 11b is byte-identical to the API — no stray bidi control characters, no HTML

Evidence points to a content/width-dependent **upstream React Native (Fabric/TextKit) RTL bug**, in the same family as the existing in-repo workarounds (`hackyFixForCantillationAtStart`, the disabled `big` tags, the removed iOS justification) and upstream reports like facebook/react-native#55220 (RTL text clipped for one specific phrase, fixed by adding a single character). The reader's per-word nested `<Text>` wrappers (clickable words) create dozens of attributed-string fragments per paragraph, which likely aggravates it.

**Recommendations for the next occurrence** (worth adding to the bug ticket):
- Capture device model, iOS version, app version, font size, and whether the segment was highlighted/long-pressed right before
- Check whether scrolling away and back heals it (would confirm a transient measure/draw mismatch rather than deterministic shaping)
- Consider filing upstream with the Chullin 11b:9 text as the repro corpus

## Test plan

- App built and run on iPhone 16/16 Plus simulators (iOS 18.6 & 26.5): reader (Hebrew, bilingual) renders correctly before/after
- Note: `npm run test-ci` currently fails on a clean `npm ci` regardless of this change — `react-localization` is not hoisted to the root of `node_modules`, so `__mocks__/react-native-localization.js` can't resolve it (pre-existing; all 11 suites fail at import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)