### PR TITLE
feat: populate TestFlight 'What to Test' for each build (sc-45192)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,10 +47,10 @@ platform :ios do
     # "What to Test" note, mirroring the Android lane's "Branch: <branch>".
     # GITHUB_REF_NAME is set in CI; git fallback is empty on detached HEAD.
     # Only useful for QA builds (story branches carry the sc-NNNNN id); skip it
-    # for master/main, where "Branch: master" would just be noise on prod builds.
+    # for master, where "Branch: master" would just be noise on prod builds.
     branch = (ENV["GITHUB_REF_NAME"] || sh("git branch --show-current").strip).strip
     testflight_changelog =
-      if branch.empty? || ["master", "main"].include?(branch)
+      if branch.empty? || branch == "master"
         nil
       else
         "Branch: #{branch}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -46,9 +46,15 @@ platform :ios do
 
     # "What to Test" note, mirroring the Android lane's "Branch: <branch>".
     # GITHUB_REF_NAME is set in CI; git fallback is empty on detached HEAD.
+    # Only useful for QA builds (story branches carry the sc-NNNNN id); skip it
+    # for master/main, where "Branch: master" would just be noise on prod builds.
     branch = (ENV["GITHUB_REF_NAME"] || sh("git branch --show-current").strip).strip
-    branch = "unknown" if branch.empty?
-    testflight_changelog = "Branch: #{branch}"
+    testflight_changelog =
+      if branch.empty? || ["master", "main"].include?(branch)
+        nil
+      else
+        "Branch: #{branch}"
+      end
 
     sh("../scripts/update_sources.sh")
     sh("cd .. && npm install") unless ENV["CI"]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -44,11 +44,8 @@ platform :ios do
       xcodeproj: "./ios/ReaderApp.xcodeproj"
     )
 
-    # "What to Test" notes for the TestFlight build, mirroring the Android
-    # testrelease lane which sets Firebase release notes to "Branch: <branch>".
-    # GITHUB_REF_NAME is always set in GitHub Actions; fall back to git for local
-    # runs. git branch --show-current is empty in a detached HEAD (what
-    # actions/checkout produces), so default to "unknown" as a last resort.
+    # "What to Test" note, mirroring the Android lane's "Branch: <branch>".
+    # GITHUB_REF_NAME is set in CI; git fallback is empty on detached HEAD.
     branch = (ENV["GITHUB_REF_NAME"] || sh("git branch --show-current").strip).strip
     branch = "unknown" if branch.empty?
     testflight_changelog = "Branch: #{branch}"
@@ -71,9 +68,8 @@ platform :ios do
       }
     )
 
-    # changelog populates TestFlight's "What to Test" field. It only attaches
-    # once the build finishes processing, which upload_to_testflight waits for
-    # by default (skip_waiting_for_build_processing is left at false).
+    # changelog = TestFlight's "What to Test"; attaches only after build
+    # processing, which upload_to_testflight waits for by default.
     upload_to_testflight(api_key: api_key, changelog: testflight_changelog)
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -44,6 +44,15 @@ platform :ios do
       xcodeproj: "./ios/ReaderApp.xcodeproj"
     )
 
+    # "What to Test" notes for the TestFlight build, mirroring the Android
+    # testrelease lane which sets Firebase release notes to "Branch: <branch>".
+    # GITHUB_REF_NAME is always set in GitHub Actions; fall back to git for local
+    # runs. git branch --show-current is empty in a detached HEAD (what
+    # actions/checkout produces), so default to "unknown" as a last resort.
+    branch = (ENV["GITHUB_REF_NAME"] || sh("git branch --show-current").strip).strip
+    branch = "unknown" if branch.empty?
+    testflight_changelog = "Branch: #{branch}"
+
     sh("../scripts/update_sources.sh")
     sh("cd .. && npm install") unless ENV["CI"]
 
@@ -62,6 +71,9 @@ platform :ios do
       }
     )
 
-    upload_to_testflight(api_key: api_key)
+    # changelog populates TestFlight's "What to Test" field. It only attaches
+    # once the build finishes processing, which upload_to_testflight waits for
+    # by default (skip_waiting_for_build_processing is left at false).
+    upload_to_testflight(api_key: api_key, changelog: testflight_changelog)
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -44,17 +44,8 @@ platform :ios do
       xcodeproj: "./ios/ReaderApp.xcodeproj"
     )
 
-    # "What to Test" note, mirroring the Android lane's "Branch: <branch>".
     # GITHUB_REF_NAME is set in CI; git fallback is empty on detached HEAD.
-    # Only useful for QA builds (story branches carry the sc-NNNNN id); skip it
-    # for master, where "Branch: master" would just be noise on prod builds.
     branch = (ENV["GITHUB_REF_NAME"] || sh("git branch --show-current").strip).strip
-    testflight_changelog =
-      if branch.empty? || branch == "master"
-        nil
-      else
-        "Branch: #{branch}"
-      end
 
     sh("../scripts/update_sources.sh")
     sh("cd .. && npm install") unless ENV["CI"]
@@ -74,8 +65,15 @@ platform :ios do
       }
     )
 
-    # changelog = TestFlight's "What to Test"; attaches only after build
-    # processing, which upload_to_testflight waits for by default.
-    upload_to_testflight(api_key: api_key, changelog: testflight_changelog)
+    # changelog populates TestFlight's "What to Test", mirroring the Android
+    # lane's "Branch: <branch>" note. Only set it for QA builds (story branches
+    # carry the sc-NNNNN id); skip on master, where "Branch: master" is just
+    # noise on prod builds. Attaches only after build processing, which
+    # upload_to_testflight waits for by default.
+    testflight_options = { api_key: api_key }
+    unless branch.empty? || branch == "master"
+      testflight_options[:changelog] = "Branch: #{branch}"
+    end
+    upload_to_testflight(testflight_options)
   end
 end


### PR DESCRIPTION
_(Claude writing on Daniel's behalf)_

Populates TestFlight's "What to Test" with `Branch: <branch>`, so testers can tell which build belongs to which story (it was blank before). Since branch names carry the story id, the note reads e.g. `Branch: feature/sc-45192/…` — same as Android's Firebase notes.

The iOS `beta` lane (`fastlane/Fastfile`) now passes `changelog:` to `upload_to_testflight`, derived from `GITHUB_REF_NAME`. Both the QA and release workflows call this one lane, so no workflow changes.

On `master` (prod release builds) the note is skipped, since `Branch: master` carries no story id and is just noise.

Closes [sc-45192](https://app.shortcut.com/sefaria/story/45192).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
