### PR TITLE
chore(sc-45626): tag analytics events with app version

### DIFF
--- a/analytics/events.js
+++ b/analytics/events.js
@@ -1,4 +1,5 @@
-import { getAnalytics, logEvent, setAnalyticsCollectionEnabled } from "@react-native-firebase/analytics";
+import { getAnalytics, logEvent, setAnalyticsCollectionEnabled, setDefaultEventParameters } from "@react-native-firebase/analytics";
+import VersionNumber from 'react-native-version-number';
 import { devLog } from '../devUtils';
 import { enrichAttributes } from './enrichments';
 
@@ -7,6 +8,7 @@ import { enrichAttributes } from './enrichments';
  */
 const initAnalytics = () => {
   setAnalyticsCollectionEnabled(getAnalytics(), true);
+  setDefaultEventParameters(getAnalytics(), { app_version: VersionNumber.appVersion });
   devLog(`Analytics initialized`);
 };
 


### PR DESCRIPTION
_(Claude writing on Daniel's behalf)_

## Summary
- Resolves the mobile slice of [sc-45178](https://app.shortcut.com/sefaria/story/45178) / [sc-45626](https://app.shortcut.com/sefaria/story/45626) ("Include Version Metadata in Analytics Events"), following the same approach already merged for web in [Sefaria-Project#3503](https://github.com/Sefaria/Sefaria-Project/pull/3503).
- Registers `app_version` (read from `react-native-version-number`, the same source already shown in the Settings screen) as a Firebase Analytics **default event parameter** once at startup (`analytics/events.js`'s `initAnalytics()`), rather than threading it through each individual event call.
- This is deliberately not done via the existing per-event `enrichAttributes()` pattern (used for dynamic fields like `is_online`/`logged_in`): app version is static for the life of a session, and critically, `trackCurrentScreen`'s `screen_view` events bypass `enrichAttributes()` entirely today — `setDefaultEventParameters` is the one place that reaches every `logEvent` call, custom and automatic alike.

## Test plan
- [x] Parse-checked the edited file with the project's babel config (repo's `jest` is currently broken on a clean install, per prior investigation, so this substitutes for a unit test run)
- [x] Built and ran the app in the iOS simulator, launched with `-FIRAnalyticsDebugEnabled -FIRDebugEnabled`, and captured Firebase's own verbose event-logging output directly from the device log (no Firebase console access needed). Confirmed `app_version = 6.7.8` is present on: Firebase's own automatic `screen_view` (origin=auto, fired at cold start before any app JS runs), our own `trackCurrentScreen` call (origin=app, e.g. the table-of-contents screen), and the automatic `user_engagement` event. Since `setDefaultEventParameters` is provider-level (not per-call), this confirms it reaches every `logEvent` invocation, not just the ones sampled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
