### PR TITLE
Hand interface-language switches back to the browser [sc-37647]

### DIFF
--- a/DeepLinkRouter.js
+++ b/DeepLinkRouter.js
@@ -106,6 +106,14 @@ class DeepLinkRouter extends React.PureComponent {
       this.catchAll({ url });
       return;
     }
+    if ('set-language-cookie' in query) {
+      // The site switches interface language by redirecting across domains
+      // (sefaria.org <-> sefaria.org.il) with this param. Android app links grab that
+      // redirect, which strands the user in the app instead of on the site they asked for.
+      // Hand it back to the browser so the language switch completes there.
+      this.catchAll({ url });
+      return;
+    }
     pathname = pathname.replace(/[\/\?]$/, '');  // remove trailing ? or /
     pathname = pathname.replace(/^[\/]/, '');  // remove initial /
     pathname = decodeURIComponent(pathname);

--- a/__tests__/DeepLinkRouter.test.js
+++ b/__tests__/DeepLinkRouter.test.js
@@ -1,0 +1,45 @@
+import DeepLinkRouter from '../DeepLinkRouter';
+
+const makeProps = () => ({
+  openNav: jest.fn(),
+  openMenu: jest.fn(),
+  openRef: jest.fn(),
+  openUri: jest.fn(),
+  openTextTocDirectly: jest.fn(),
+  openSearch: jest.fn(),
+  openTopic: jest.fn(),
+  setSearchOptions: jest.fn(),
+  setTextLanguage: jest.fn(),
+  setNavigationCategories: jest.fn(),
+});
+
+beforeAll(() => {
+  global.Sefaria = { api: { _baseHost: 'https://www.sefaria.org/' } };
+});
+
+describe('DeepLinkRouter interface language switching', () => {
+  test('hands a cross-domain language switch back to the browser', () => {
+    const props = makeProps();
+    const router = new DeepLinkRouter(props);
+    router.route('https://www.sefaria.org/texts?set-language-cookie=', true);
+    expect(props.openUri).toHaveBeenCalledWith('https://www.sefaria.org/texts?set-language-cookie=');
+    expect(props.openNav).not.toHaveBeenCalled();
+  });
+
+  test('hands a language switch to the Hebrew domain back to the browser', () => {
+    const props = makeProps();
+    const router = new DeepLinkRouter(props);
+    const url = 'https://www.sefaria.org.il/Genesis.1?set-language-cookie=';
+    router.route(url, true);
+    expect(props.openUri).toHaveBeenCalledWith(url);
+    expect(props.openRef).not.toHaveBeenCalled();
+  });
+
+  test('still opens ordinary deep links in the app', () => {
+    const props = makeProps();
+    const router = new DeepLinkRouter(props);
+    router.route('https://www.sefaria.org/texts', true);
+    expect(props.openNav).toHaveBeenCalled();
+    expect(props.openUri).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes [sc-37647](https://app.shortcut.com/sefaria/story/37647).

## Why a mobile-web bug is fixed in the app

The symptom shows up on mobile web, but the thing that breaks it is the Android app.

Reported flow: on an Android phone in Israel, open `www.sefaria.org` in the browser, get the Hebrew site, tap **English**. Instead of landing on the English site, the phone jumps into the Sefaria app.

The site switches interface language by navigating to a URL carrying `?set-language-cookie=`, and that navigation crosses domains (`sefaria.org` ↔ `sefaria.org.il`). The Sefaria Android app registers both of those domains as **App Links**, so Android sees a cross-domain navigation to a URL the app claims and hands it to the app instead of letting the browser follow it. The app then treats it as an ordinary deep link and opens the requested page in the app — the language switch never completes, and the user is left in the app rather than on the site they asked for.

Nothing on the web side can veto that: the interception happens in Android's link-handling layer, before any Sefaria web code runs. The only component that gets a say is the app, which can look at the URL it was handed and decline it. That's what this PR does.

## The fix

`DeepLinkRouter` now recognizes a language-switch URL (`set-language-cookie` present in the query) and routes it to `catchAll`, which hands the URL to the browser instead of resolving it to an in-app screen. Ordinary Sefaria deep links are untouched and still open in the app.

That's the whole change — one guard clause in `DeepLinkRouter.js`, plus tests. No native/Android code changed.

## Verification

Unit tests in `__tests__/DeepLinkRouter.test.js` (3/3 passing) cover:
- a `set-language-cookie` URL on `sefaria.org` → handed to the browser, not opened in-app
- a `set-language-cookie` URL on `sefaria.org.il` → same
- an ordinary URL (`/texts`) → still opens in the app (regression guard)

## Note for review

The app hands the URL to `openUri`, which opens a Chrome Custom Tab and falls back to the phone's default browser. So the language switch completes in a real browser context, but the user ends up in a browser surface launched from the app rather than back in the original Chrome tab they started in. Returning them to the exact originating tab isn't something the app can control once Android has already routed the link to it. Happy to discuss if we want a different treatment here.
