### PR TITLE
ci: provision SSO env vars for release builds

### DIFF
--- a/.github/workflows/deploy-android-release.yml
+++ b/.github/workflows/deploy-android-release.yml
@@ -87,6 +87,19 @@ jobs:
       - name: Install npm dependencies
         run: npm install
 
+      # react-native-config bakes .env into the built binary at build time.
+      # These are public OAuth client identifiers (they are extractable from any
+      # shipped APK/IPA by design), so they live in GitHub *variables*, not
+      # secrets. BASE_HOST is deliberately NOT set here: api.js falls back to
+      # https://www.sefaria.org/ so a release can never point at a cauldron.
+      - name: Create .env for react-native-config
+        env:
+          GOOGLE_SSO_CLIENT_ID: ${{ vars.GOOGLE_SSO_CLIENT_ID }}
+          GOOGLE_SSO_IOS_CLIENT_ID: ${{ vars.GOOGLE_SSO_IOS_CLIENT_ID }}
+        run: |
+          printf 'GOOGLE_SSO_CLIENT_ID=%s\n'     "$GOOGLE_SSO_CLIENT_ID"     >  .env
+          printf 'GOOGLE_SSO_IOS_CLIENT_ID=%s\n' "$GOOGLE_SSO_IOS_CLIENT_ID" >> .env
+
       - name: Decode Android keystore
         # Decode to both android/ and android/app/ — Gradle resolves the path
         # relative to the :app subproject directory, but this varies by Gradle version.

--- a/.github/workflows/deploy-android.yml
+++ b/.github/workflows/deploy-android.yml
@@ -59,6 +59,19 @@ jobs:
       - name: Install npm dependencies
         run: npm install
 
+      # react-native-config bakes .env into the built binary at build time.
+      # These are public OAuth client identifiers (they are extractable from any
+      # shipped APK/IPA by design), so they live in GitHub *variables*, not
+      # secrets. BASE_HOST is deliberately NOT set here: api.js falls back to
+      # https://www.sefaria.org/ so a release can never point at a cauldron.
+      - name: Create .env for react-native-config
+        env:
+          GOOGLE_SSO_CLIENT_ID: ${{ vars.GOOGLE_SSO_CLIENT_ID }}
+          GOOGLE_SSO_IOS_CLIENT_ID: ${{ vars.GOOGLE_SSO_IOS_CLIENT_ID }}
+        run: |
+          printf 'GOOGLE_SSO_CLIENT_ID=%s\n'     "$GOOGLE_SSO_CLIENT_ID"     >  .env
+          printf 'GOOGLE_SSO_IOS_CLIENT_ID=%s\n' "$GOOGLE_SSO_IOS_CLIENT_ID" >> .env
+
       - name: Install Firebase CLI
         # Firebase CLI is used by the testrelease lane to distribute the APK.
         # It handles first-time App Distribution app initialisation, which the

--- a/.github/workflows/deploy-ios-release.yml
+++ b/.github/workflows/deploy-ios-release.yml
@@ -70,6 +70,19 @@ jobs:
       - name: Install npm dependencies
         run: npm install
 
+      # react-native-config bakes .env into the built binary at build time.
+      # These are public OAuth client identifiers (they are extractable from any
+      # shipped APK/IPA by design), so they live in GitHub *variables*, not
+      # secrets. BASE_HOST is deliberately NOT set here: api.js falls back to
+      # https://www.sefaria.org/ so a release can never point at a cauldron.
+      - name: Create .env for react-native-config
+        env:
+          GOOGLE_SSO_CLIENT_ID: ${{ vars.GOOGLE_SSO_CLIENT_ID }}
+          GOOGLE_SSO_IOS_CLIENT_ID: ${{ vars.GOOGLE_SSO_IOS_CLIENT_ID }}
+        run: |
+          printf 'GOOGLE_SSO_CLIENT_ID=%s\n'     "$GOOGLE_SSO_CLIENT_ID"     >  .env
+          printf 'GOOGLE_SSO_IOS_CLIENT_ID=%s\n' "$GOOGLE_SSO_IOS_CLIENT_ID" >> .env
+
       - name: Install CocoaPods
         working-directory: ios
         run: |

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -27,6 +27,19 @@ jobs:
       - name: Install npm dependencies
         run: npm install
 
+      # react-native-config bakes .env into the built binary at build time.
+      # These are public OAuth client identifiers (they are extractable from any
+      # shipped APK/IPA by design), so they live in GitHub *variables*, not
+      # secrets. BASE_HOST is deliberately NOT set here: api.js falls back to
+      # https://www.sefaria.org/ so a release can never point at a cauldron.
+      - name: Create .env for react-native-config
+        env:
+          GOOGLE_SSO_CLIENT_ID: ${{ vars.GOOGLE_SSO_CLIENT_ID }}
+          GOOGLE_SSO_IOS_CLIENT_ID: ${{ vars.GOOGLE_SSO_IOS_CLIENT_ID }}
+        run: |
+          printf 'GOOGLE_SSO_CLIENT_ID=%s\n'     "$GOOGLE_SSO_CLIENT_ID"     >  .env
+          printf 'GOOGLE_SSO_IOS_CLIENT_ID=%s\n' "$GOOGLE_SSO_IOS_CLIENT_ID" >> .env
+
       - name: Install CocoaPods
         working-directory: ios
         run: |


### PR DESCRIPTION
## Problem

The app reads `GOOGLE_SSO_CLIENT_ID` and `GOOGLE_SSO_IOS_CLIENT_ID` through `react-native-config`, which bakes `.env` into the binary **at build time**. No workflow has ever created a `.env`, so CI-built apps ship with both values `undefined` — meaning Google Sign-In cannot work in a released build, independently of any OAuth-client configuration.

Verified by inspection: no `.env` is written anywhere under `.github/workflows/`, `fastlane/`, or `scripts/`.

## Change

Adds a `Create .env for react-native-config` step to the four deploy workflows (Android QA/release, iOS QA/release), immediately after `npm install` so it precedes every build.

## Why variables and not secrets

These are **public OAuth client identifiers**. They are extractable from any shipped APK/IPA by design — masking them in CI logs buys nothing, and treating them as secrets makes them harder for developers to obtain legitimately. They are therefore read from GitHub **repository variables**.

## Setup required before merge

Two repository variables must be configured (Settings → Secrets and variables → Actions → **Variables**):

| Variable | Value |
|---|---|
| `GOOGLE_SSO_CLIENT_ID` | the Google **Web** OAuth client ID |
| `GOOGLE_SSO_IOS_CLIENT_ID` | the Google **iOS** OAuth client ID |

Until they are set the step writes empty values, which is no worse than today's behaviour (absent).

## Notes

- `BASE_HOST` is deliberately **not** set, so `api.js` falls back to `https://www.sefaria.org/`. A release can therefore never be built pointing at a cauldron.
- No `APPLE_SSO_*` variable is included: none of them is referenced by any JS or native config in this repo — they are Django settings. In particular `APPLE_SSO_PRIVATE_KEY` must never be added here, since `react-native-config` would bake it into the shipped binary.
- Values are passed via an `env:` block and `printf` rather than interpolated directly into the `run:` script, avoiding shell injection on the expression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2KcNAoRp7cdaf67qMdXDZ